### PR TITLE
Refactor FetchVersion to use ScheduledExecutorService

### DIFF
--- a/Common/src/main/java/one/tranic/goldpiglin/common/data/FetchVersion.java
+++ b/Common/src/main/java/one/tranic/goldpiglin/common/data/FetchVersion.java
@@ -8,6 +8,8 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Date;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class FetchVersion {
@@ -15,7 +17,7 @@ public class FetchVersion {
     private final String oldVersion;
     private String newVersion;
     private Date lastUpdate = new Date();
-    private Thread updateThread;
+    private ScheduledExecutorService scheduler;
 
     public FetchVersion(String local) {
         this.oldVersion = local;
@@ -27,20 +29,17 @@ public class FetchVersion {
     }
 
     public void run() {
-        updateThread = JVMThread.newVirtualThreadFactoryOrDefault().newThread(() -> {
-            try {
-                TimeUnit.HOURS.sleep(2);
-            } catch (Exception ignored) {
-            }
-            this.checkForUpdates();
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = JVMThread.newVirtualThreadFactoryOrDefault().newThread(r);
+            t.setName("GoldPiglin Updater Thread");
+            return t;
         });
-        updateThread.setName("GoldPiglin Updater Thread");
-        updateThread.start();
+        scheduler.schedule(this::checkForUpdates, 2, TimeUnit.HOURS);
     }
 
     public void stop() {
-        if (updateThread != null) {
-            updateThread.interrupt();
+        if (scheduler != null && !scheduler.isShutdown()) {
+            scheduler.shutdownNow();
         }
     }
 


### PR DESCRIPTION
This PR refactors `FetchVersion.java` to replace a manual thread sleeping mechanism with a `ScheduledExecutorService`.

**Changes:**
- Removed `Thread updateThread` field.
- Added `ScheduledExecutorService scheduler` field.
- In `run()`, initialize a single-threaded scheduled executor using `Executors.newSingleThreadScheduledExecutor` with a thread factory that respects the project's `JVMThread` utility (potentially using virtual threads) and names the thread "GoldPiglin Updater Thread".
- Scheduled the `checkForUpdates` task to run after a 2-hour delay.
- Updated `stop()` to shutdown the scheduler if it's running.

**Verification:**
- Verified that `Common` module compiles successfully.
- Code review confirmed the implementation is correct and follows best practices.

---
*PR created automatically by Jules for task [17929370271533103058](https://jules.google.com/task/17929370271533103058) started by @404Setup*