### PR TITLE
🧹 Fix potential thread pool exhaustion in Scheduler

### DIFF
--- a/Common/build.gradle.kts
+++ b/Common/build.gradle.kts
@@ -6,6 +6,9 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:24.1.0")
     compileOnly("it.unimi.dsi:fastutil:8.5.15")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.0")
+    testImplementation("one.pkg:tiny-utils:2.2.0")
 }
 
 val targetJavaVersion = 17
@@ -24,4 +27,8 @@ tasks.withType<JavaCompile>().configureEach {
     if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible) {
         options.release.set(targetJavaVersion)
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/Common/src/main/java/one/tranic/goldpiglin/common/data/Scheduler.java
+++ b/Common/src/main/java/one/tranic/goldpiglin/common/data/Scheduler.java
@@ -8,7 +8,7 @@ import java.util.concurrent.Executors;
 
 public class Scheduler {
     private static final ExecutorService executor = Executors.newSingleThreadExecutor(JVMThread.newVirtualThreadFactoryOrDefault());
-    private static final ExecutorService asyncExecutor = Executors.newFixedThreadPool(3, JVMThread.newVirtualThreadFactoryOrDefault());
+    private static final ExecutorService asyncExecutor = Executors.newCachedThreadPool(JVMThread.newVirtualThreadFactoryOrDefault());
 
     private Scheduler() {
     }

--- a/Common/src/test/java/one/tranic/goldpiglin/common/data/SchedulerTest.java
+++ b/Common/src/test/java/one/tranic/goldpiglin/common/data/SchedulerTest.java
@@ -1,0 +1,46 @@
+package one.tranic.goldpiglin.common.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SchedulerTest {
+
+    @Test
+    void testAsyncExecutorConcurrency() throws InterruptedException {
+        int numberOfTasks = 10;
+        CountDownLatch startLatch = new CountDownLatch(numberOfTasks);
+        CountDownLatch finishLatch = new CountDownLatch(1);
+        AtomicInteger runningTasks = new AtomicInteger(0);
+
+        for (int i = 0; i < numberOfTasks; i++) {
+            Scheduler.asyncExecute(() -> {
+                runningTasks.incrementAndGet();
+                startLatch.countDown();
+                try {
+                    // Wait until test allows us to finish
+                    if (!finishLatch.await(5, TimeUnit.SECONDS)) {
+                        System.err.println("Task timed out waiting for finishLatch");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        // Wait for all tasks to start
+        // If we were using a fixed pool of 3, only 3 tasks would start and we would timeout here (because startLatch needs 10)
+        boolean allStarted = startLatch.await(5, TimeUnit.SECONDS);
+
+        assertTrue(allStarted, "Not all tasks started concurrently. Potential thread pool exhaustion or limit. Running tasks: " + runningTasks.get());
+        assertEquals(numberOfTasks, runningTasks.get(), "Should have " + numberOfTasks + " tasks running.");
+
+        // Let them finish
+        finishLatch.countDown();
+    }
+}


### PR DESCRIPTION
Replaced `newFixedThreadPool(3)` with `newCachedThreadPool` for `asyncExecutor` in `Scheduler.java`.
This prevents thread pool exhaustion when multiple long-running or blocking tasks are submitted (e.g., by `ExpiringHashMap`).
Added `SchedulerTest` to verify that more than 3 blocking tasks can run concurrently.
Added `junit-jupiter`, `junit-platform-launcher`, and `tiny-utils` to test dependencies in `Common/build.gradle.kts`.

---
*PR created automatically by Jules for task [13595786712003770382](https://jules.google.com/task/13595786712003770382) started by @404Setup*