### PR TITLE
Optimize thread usage for `FetchVersion` update check

### DIFF
--- a/Common/src/main/java/one/pkg/goldpiglin/common/data/FetchVersion.java
+++ b/Common/src/main/java/one/pkg/goldpiglin/common/data/FetchVersion.java
@@ -8,8 +8,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Date;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class FetchVersion {
@@ -17,7 +16,7 @@ public class FetchVersion {
     private final String oldVersion;
     private String newVersion;
     private Date lastUpdate = new Date();
-    private ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> scheduledTask;
 
     public FetchVersion(String local) {
         this.oldVersion = local;
@@ -29,17 +28,12 @@ public class FetchVersion {
     }
 
     public void run() {
-        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = JVMThread.newVirtualThreadFactoryOrDefault().newThread(r);
-            t.setName("GoldPiglin Updater Thread");
-            return t;
-        });
-        scheduler.schedule(this::checkForUpdates, 2, TimeUnit.HOURS);
+        scheduledTask = Scheduler.schedule(this::checkForUpdates, 2, TimeUnit.HOURS);
     }
 
     public void stop() {
-        if (scheduler != null && !scheduler.isShutdown()) {
-            scheduler.shutdownNow();
+        if (scheduledTask != null && !scheduledTask.isCancelled()) {
+            scheduledTask.cancel(true);
         }
     }
 

--- a/Common/src/main/java/one/pkg/goldpiglin/common/data/Scheduler.java
+++ b/Common/src/main/java/one/pkg/goldpiglin/common/data/Scheduler.java
@@ -5,12 +5,20 @@ import one.pkg.tinyutils.jvm.JVMThread;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 public class Scheduler {
     private static final ExecutorService executor = Executors.newSingleThreadExecutor(JVMThread.newVirtualThreadFactoryOrDefault());
     private static final ExecutorService asyncExecutor = Executors.newCachedThreadPool(JVMThread.newVirtualThreadFactoryOrDefault());
+    private static final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor(JVMThread.newVirtualThreadFactoryOrDefault());
 
     private Scheduler() {
+    }
+
+    public static ScheduledFuture<?> schedule(Runnable runnable, long delay, TimeUnit unit) {
+        return scheduledExecutor.schedule(runnable, delay, unit);
     }
 
     public static void execute(Runnable runnable) {
@@ -24,5 +32,6 @@ public class Scheduler {
     public static void shutdown() {
         executor.shutdown();
         asyncExecutor.shutdown();
+        scheduledExecutor.shutdown();
     }
 }

--- a/Common/src/test/java/one/pkg/goldpiglin/common/data/ExpiringHashMapTest.java
+++ b/Common/src/test/java/one/pkg/goldpiglin/common/data/ExpiringHashMapTest.java
@@ -19,11 +19,6 @@ class ExpiringHashMapTest {
         map = new ExpiringHashMap<>(5, 1);
     }
 
-    @AfterAll
-    static void tearDown() {
-        Scheduler.shutdown();
-    }
-
     @Test
     void testEntrySetReturnsCorrectEntries() {
         map.put("key1", "value1");


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the inefficient use of threads in `FetchVersion`, which created its own `ScheduledExecutorService` instead of using standard, efficient scheduling.
💡 **Why:** Centralizing scheduled tasks into the existing `Scheduler` class improves code maintainability and execution efficiency. It reduces duplicate logic and makes thread lifecycle management consistent.
✅ **Verification:** Verified by checking the updated files and successfully running module tests (`./gradlew :Common:test`). Note: An existing test teardown method making an incorrect call to `Scheduler.shutdown()` had to be removed to fix a test failure. Code changes received a #Correct# code review.
✨ **Result:** The update polling task now uses a standard and efficient `ScheduledFuture` through the centralized `Scheduler`.

---
*PR created automatically by Jules for task [485980369523961044](https://jules.google.com/task/485980369523961044) started by @404Setup*